### PR TITLE
Implement temporary password change flow

### DIFF
--- a/app/change-password/page.tsx
+++ b/app/change-password/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase";
+
+export default function ChangePasswordPage() {
+  const router = useRouter();
+
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const handlePasswordUpdate = async (
+    e: React.FormEvent<HTMLFormElement>
+  ) => {
+    e.preventDefault();
+
+    setError("");
+    setSuccess("");
+
+    if (newPassword !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    // Get current logged-in user
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      setError("User not found.");
+      return;
+    }
+
+    // Update Supabase Auth password
+    const { error: passwordError } = await supabase.auth.updateUser({
+      password: newPassword,
+    });
+
+    if (passwordError) {
+      setError(passwordError.message);
+      return;
+    }
+
+    // Update profile flag
+    const { error: profileError } = await supabase
+      .from("profiles")
+      .update({ is_temporary_password: false })
+      .eq("id", user.id);
+
+    if (profileError) {
+      setError(profileError.message);
+      return;
+    }
+
+    setSuccess("Password updated successfully!");
+
+    // Redirect after success
+    setTimeout(() => {
+        router.push("/")
+      }, 1500);
+  };
+
+  return (
+    <main className="min-h-screen flex items-center justify-center p-6">
+      <div className="w-full max-w-md border rounded-lg p-6 shadow">
+        <h1 className="text-2xl font-bold mb-4">Change Password</h1>
+
+        <form onSubmit={handlePasswordUpdate} className="space-y-4">
+          <div>
+            <label className="block mb-1 font-medium">
+              New Password
+            </label>
+
+            <input
+              type="password"
+              className="w-full border rounded p-2"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+            />
+          </div>
+
+          <div>
+            <label className="block mb-1 font-medium">
+              Confirm Password
+            </label>
+
+            <input
+              type="password"
+              className="w-full border rounded p-2"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+            />
+          </div>
+
+          {error && (
+            <p className="text-red-500 text-sm">
+              {error}
+            </p>
+          )}
+
+          {success && (
+            <p className="text-green-500 text-sm">
+              {success}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            className="w-full rounded bg-black text-white p-2"
+          >
+            Update Password
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -28,7 +28,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       const { data } = await supabase
         .from('profiles')
-        .select('id, role')
+        .select('id, role, is_temporary_password')
         .eq('id', user.id)
         .single()
 

--- a/components/RouteGuard.tsx
+++ b/components/RouteGuard.tsx
@@ -21,6 +21,11 @@ export default function RouteGuard({ allowedRoles, children }: Props) {
       router.replace('/login')
       return
     }
+    
+    if (profile.is_temporary_password) {
+      router.replace('/change-password')
+      return
+    }
 
     if (!allowedRoles.includes(profile.role)) {
       router.replace('/unauthorized')

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -4,4 +4,5 @@ export type UserProfile = {
   id: string
   email: string
   role: UserRole
+  is_temporary_password?: boolean
 }


### PR DESCRIPTION
Resolves: #43 
Resolves: #36 


## Description

Implemented a temporary password change flow for new users.

### Changes Made

* Created `/change-password` page
* Added password update form with confirmation validation
* Integrated Supabase Auth password update flow
* Added profile update logic to set `is_temporary_password` to `false`
* Updated `AuthProvider` to fetch `is_temporary_password`
* Added redirect protection in `RouteGuard`
* Prevented users with temporary passwords from accessing protected dashboards until password is updated
* Added delayed redirect after successful password update so success message is visible

## Testing Instructions

1. Create or use a user with:

   * `is_temporary_password = TRUE`
   * valid role (`contractor`, `client`, or `admin`)

2. Log into the application using that account

3. Attempt to access a protected route:

   * `/login/contractor`
   * `/login/client`
   * `/login/admin`

4. Verify user is redirected to:

   * `/change-password`

5. Enter a new password and confirm it

6. Verify:

   * success message appears
   * user is redirected after update
   * `is_temporary_password` changes to `FALSE` in Supabase
   * user can now access their correct dashboard normally

7. Verify unauthorized role routes still redirect to:

   * `/unauthorized`

Existing role-based access control behavior remains functional after implementing the password change flow.

<img width="1920" height="1080" alt="Screenshot 2026-05-15 at 12 17 56 PM" src="https://github.com/user-attachments/assets/79a7cd8b-e8f0-4a91-81d3-469974c6faff" />
