### PR TITLE
[Wiki] Create Central Hub Wiki Page: Project Overview and The Three Roles (#70)

### DIFF
--- a/docs/nwd-central-hub-prototype.md
+++ b/docs/nwd-central-hub-prototype.md
@@ -1,0 +1,61 @@
+# NWD Central Hub Prototype
+
+## What Is the NWD Central Hub?
+
+The NWD Central Hub is an internal project coordination platform used by Next Wave Dev (NWD). It centralizes project workflows that would otherwise be handled manually through email, spreadsheets, and meetings.
+
+Organizations can submit project proposals, administrators can review and approve submissions, and contractors can request assignments and deliver project work. The platform streamlines communication, project tracking, and collaboration between all participants.
+
+---
+
+## Project Status
+
+**Current Phase:** MVP (Minimum Viable Product)
+
+The platform is currently under active development by Next Wave Dev contributors and mentors.
+
+Maintained by:
+- NWD Staff
+- Senior Developers
+- Practicum Contributors
+
+---
+
+## The Three Roles
+
+| Role | Who They Are | What They Do |
+|------|-------------|-------------|
+| Admin | NWD staff and senior developers | Manage users, review proposals, oversee projects |
+| Client | External organizations | Submit project proposals, track project status |
+| Contractor | NWD graduate students | Browse approved proposals, request project assignment, deliver work |
+
+---
+
+## Repository
+
+Repository: https://github.com/next-wave-dev-org/nwd-central-hub-prototype
+
+**Note:** This repository is private and accessible only to authorized contributors.
+
+---
+
+## Related Wiki Pages
+
+- [[Home]]
+- [[RBAC]]
+- [[Next Wave Dev (NWD) -- Static Website]]
+
+### Future Documentation
+
+- Project Lifecycle
+- Proposal Review Process
+- User Management
+- Contractor Workflow
+
+---
+
+## Navigation
+
+Return to the main wiki:
+
+[[Home]]

--- a/docs/wiki-home-redesign.md
+++ b/docs/wiki-home-redesign.md
@@ -1,0 +1,46 @@
+# Proposed NWD Wiki Home Page Update
+
+## Active Projects
+
+### NWD Central Hub Prototype
+
+NWD Central Hub is the internal coordination platform for Next Wave Dev. It centralizes the workflow that NWD already operates manually: client organizations submit project proposals, NWD staff review and approve them, and NWD graduate contractors are assigned to and work on those projects.
+
+Repository:
+https://github.com/next-wave-dev-org/nwd-central-hub-prototype
+
+Wiki Page:
+[[NWD Central Hub Prototype]]
+
+---
+
+### NWD Static Website
+
+Public-facing website for Next Wave Dev that provides organizational information, branding, and public resources.
+
+Repository:
+https://github.com/next-wave-dev-org/nwd-static-website
+
+Wiki Page:
+[[Next Wave Dev (NWD) -- Static Website]]
+
+---
+
+## Wiki Cross-Linking Reference
+
+```md
+<!-- Exact page title creates a link automatically -->
+[[NWD Central Hub Prototype]]
+
+<!-- Custom link text to another wiki page -->
+[Central Hub Project](NWD-Central-Hub-Prototype)
+
+<!-- Link to a specific section on another page -->
+[Tech Stack](NWD-Central-Hub-Prototype#tech-stack)
+
+<!-- Link back to wiki home -->
+[[Home]]
+
+<!-- Link to the static site page -->
+[[Next Wave Dev (NWD) -- Static Website]]
+```


### PR DESCRIPTION
## Summary & Changes 📃

Resolves: #70

### Summary

Creates the top-level wiki page for the NWD Central Hub Prototype. This page serves as the primary entry point for Central Hub documentation and provides an overview of the platform, project status, user roles, repository information, and related wiki pages.

### Changes

* Added NWD Central Hub Prototype wiki page
* Added platform overview section explaining the purpose of the Central Hub
* Added Project Status section documenting the current MVP phase
* Added Three Roles table describing Admin, Client, and Contractor responsibilities
* Added repository reference with privacy notice
* Added related wiki page links and navigation references
* Added link back to the Home wiki page
* No breaking changes

## Screenshots / Visual Aids 🔎

Documentation-only change.

## How to Test 🧪

1. Open the wiki page documentation file.
2. Verify the page title is exactly **NWD Central Hub Prototype**.
3. Verify all required sections are present:

   * What Is the NWD Central Hub?
   * Project Status
   * The Three Roles
   * Repository
   * Related Wiki Pages
4. Verify role descriptions match issue requirements.
5. Verify repository privacy note is present.
6. Verify Home wiki link exists.

### Expected Behavior

The documentation provides a clear overview of the Central Hub platform and serves as a central navigation point for related wiki pages.

### Actual Behavior

Documentation was created according to the requirements specified in Issue #70.

## Notes

This page is intended to serve as the parent documentation page for future Central Hub wiki content and cross-linking.

## Update Relevant Documents 📚

* Wiki Documentation
* docs/

## Checklist ✅

* [x] Documentation created and reviewed
* [x] Resolves Issue #70
* [x] Wiki links added
* [x] No credentials, keys, or environment variables included
